### PR TITLE
Fix: Spend Logs Update bug

### DIFF
--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -3,6 +3,7 @@ import os
 import secrets
 import traceback
 from typing import Optional
+from pydantic import BaseModel
 
 import litellm
 from litellm._logging import verbose_proxy_logger
@@ -105,6 +106,8 @@ def get_logging_payload(
     additional_usage_values = {}
     for k, v in usage.items():
         if k not in special_usage_fields:
+            if isinstance(v, BaseModel):
+                v = v.model_dump()
             additional_usage_values.update({k: v})
     clean_metadata["additional_usage_values"] = additional_usage_values
 


### PR DESCRIPTION
## Title

Fix: Spend Logs Update bug 

## Type

🐛 Bug Fix


## Changes

additional_usage_values added to clean_metadata has a pydantic object which gave error while json dumps.
Added a check, if value is instance of BaseModel, then convert it to dict using model_dump().

Manual testing done to ensure spend logs are getting inserted in db.

