### PR TITLE
feat: added support for bud user jwt and project id

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -17,6 +17,8 @@ from fastapi import HTTPException, Request, WebSocket, status
 from fastapi.security.api_key import APIKeyHeader
 
 import litellm
+from litellm.commons.config import app_settings
+from litellm.proxy.budserve_middleware import _get_user_jwt, _get_project_id
 from litellm._logging import verbose_logger, verbose_proxy_logger
 from litellm._service_logger import ServiceLogging
 from litellm.caching import DualCache
@@ -520,6 +522,12 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
                 ),
                 kind=open_telemetry_logger.span_kind.SERVER,
             )
+
+        ### IF USER JWT AND PROJECT ID ARE PASSED IN, BYPASS WITH MASTER KEY ###
+        user_jwt = await _get_user_jwt(request)
+        project_id = await _get_project_id(request)
+        if user_jwt and project_id:
+            return UserAPIKeyAuth(api_key=app_settings.litellm_master_key)
 
         ### USER-DEFINED AUTH FUNCTION ###
         if user_custom_auth is not None:

--- a/litellm/proxy/budserve_middleware.py
+++ b/litellm/proxy/budserve_middleware.py
@@ -2,8 +2,11 @@ import json
 import httpx
 import os
 
+from typing import Optional
+
 from litellm.commons.config import app_settings, secrets_settings
 
+from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy.auth.auth_utils import get_request_route
@@ -39,17 +42,30 @@ class BudServeMiddleware(BaseHTTPMiddleware):
         elif api_key_header:
             api_key = api_key_header
         return api_key
-    
-    async def fetch_user_config(self, api_key: str, endpoint_name: str):
+
+    async def fetch_user_config(self, api_key: Optional[str], endpoint_name: str, user_jwt: Optional[str], project_id: Optional[str]):
         # redis key : router_config:{api_key}:{endpoint_name}
         budserve_app_baseurl = os.getenv('BUDSERVE_APP_BASEURL', 'http://localhost:9000')
         url = f"{budserve_app_baseurl}/credentials/router-config"
+
+        # Build params
+        params={"endpoint_name": endpoint_name}
+        if api_key:
+            params["api_key"] = api_key
+        if project_id:
+            params["project_id"] = project_id
+
+        # Build headers
+        headers={"Content-Type": "application/json"}
+        if user_jwt:
+            headers["Authorization"] = f"Bearer {user_jwt}"
+
         try:
             async with httpx.AsyncClient() as client:
                 response = await client.get(
                     url,
-                    params={"api_key": api_key, "endpoint_name": endpoint_name},
-                    headers={"Content-Type": "application/json"},
+                    params=params,
+                    headers=headers,
                     follow_redirects=True
                 )
                 verbose_proxy_logger.debug(f"Response: {response}")
@@ -102,9 +118,14 @@ class BudServeMiddleware(BaseHTTPMiddleware):
         request.state.original_body = json.dumps(request_data)
         api_key = await self.get_api_key(request)
         endpoint_name = request_data.get("model")
+        user_jwt = await _get_user_jwt(request)
+        project_id = await _get_project_id(request)
+        # if user_jwt is present, api_key change to None
+        if user_jwt:
+            api_key = None
 
         # get endpoint details to fill cache_params
-        user_config = await self.fetch_user_config(api_key, endpoint_name)
+        user_config = await self.fetch_user_config(api_key, endpoint_name, user_jwt, project_id)
         
         user_config["cache_configuration"] = {
             "score_threshold": 0.5,
@@ -167,3 +188,21 @@ class BudServeMiddleware(BaseHTTPMiddleware):
         }
         request._body = json.dumps(request_data).encode("utf-8")
         return await call_next(request)
+
+
+async def _get_user_jwt(request: Request):
+    """Get the user jwt from the request headers"""
+    authorization_header = request.headers.get("Authorization")
+    if authorization_header:
+        auth_token = authorization_header.split(" ")[1]
+
+        if auth_token and isinstance(auth_token, str):
+            auth_token_len = auth_token.split(".")
+            if len(auth_token_len) == 3:
+                return auth_token
+
+    return None
+
+async def _get_project_id(request: Request):
+    """Get the project id from the request headers"""
+    return request.headers.get("Project-Id")

--- a/litellm_config.yaml
+++ b/litellm_config.yaml
@@ -1,6 +1,7 @@
 general_settings:
   store_model_in_db: True
   custom_auth: litellm.custom_auth.user_api_key_auth
+  master_key: "os.environ/LITELLM_MASTER_KEY"
 router_settings:
   cache_responses: False
   redis_host: "os.environ/REDIS_HOST"


### PR DESCRIPTION
### Title: Feature: Add Authentication Options for LiteLLM Inference

#### Linked Issues

- Closes https://github.com/BudEcosystem/bud-serve/issues/2138

#### Description

This PR enhances the LiteLLM inference API by enabling authentication through either a user JWT and project ID combination or an API key. This provides flexibility in access control while ensuring security.

#### Methodology/Tasks Implemented

- Added support for user JWT and project ID combination for authentication.
- Reuse existing API key-based authentication as an alternative method.
- Updated request validation logic to check for either authentication method.

#### Testing

- Verified inference requests using user JWT and project ID.
- Tested API key authentication for inference.
- Ensured correct authorization handling in all scenarios.

#### Estimated Time

- Approximately 4 hours.

#### Screenshots/Logs

using jwt and project id
<img width="1059" alt="image" src="https://github.com/user-attachments/assets/d2756833-0bb5-4339-9f3f-cb182e4b9dba" />

using api key
<img width="1059" alt="image" src="https://github.com/user-attachments/assets/05386046-6b5d-44f1-9507-cf2e601a6479" />